### PR TITLE
Implement `Styled` for `List`.

### DIFF
--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::cast_possible_truncation)]
 use ratatui::{
     prelude::{Buffer, Rect},
-    style::Style,
+    style::{Style, Styled},
     widgets::{Block, StatefulWidget, Widget},
 };
 
@@ -48,13 +48,6 @@ impl<'a, T: PreRender> List<'a, T> {
         self
     }
 
-    /// Set the base style of the List.
-    #[must_use]
-    pub fn style(mut self, style: Style) -> Self {
-        self.style = style;
-        self
-    }
-
     /// Checks whether the widget list is empty.
     #[must_use]
     pub fn is_empty(&self) -> bool {
@@ -67,10 +60,29 @@ impl<'a, T: PreRender> List<'a, T> {
         self.items.len()
     }
 
+    /// Set the base style of the List.
+    #[must_use]
+    pub fn style<S: Into<Style>>(mut self, style: S) -> Self {
+        self.style = style.into();
+        self
+    }
+
     /// Set the scroll direction of the list.
     #[must_use]
     pub fn scroll_direction(mut self, scroll_axis: ScrollAxis) -> Self {
         self.scroll_axis = scroll_axis;
+        self
+    }
+}
+
+impl<T: PreRender> Styled for List<'_, T> {
+    type Item = Self;
+    fn style(&self) -> Style {
+        self.style
+    }
+
+    fn set_style<S: Into<Style>>(mut self, style: S) -> Self::Item {
+        self.style = style.into();
         self
     }
 }


### PR DESCRIPTION
Examples, and documentation have been updated.

Didn't need to remove `List::style` as `ratatui` seperates `Styled`, and `Stylize` traits which means only people who are implementing `Styled` and using the `List::style` method  in the same module may be affected. 

This is what is done in `ratatui` as well. Even though a much smaller number of people will be effected, I think its still a breaking change. (for example [Line](https://docs.rs/ratatui/latest/ratatui/text/struct.Line.html) has a `style` method and implements `Styled`)