### PR TITLE
Enhancement: Expose Trunctation Amount 

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -175,4 +175,20 @@ impl ListState {
     pub fn scroll_offset_index(&self) -> usize {
         self.view_state.offset
     }
+
+    /// Returns the number of rows/columns of the first visible item that are scrolled off the top/left.
+    ///
+    /// When the first visible item is partially scrolled out of view, this returns how many
+    /// rows (for vertical lists) or columns (for horizontal lists) are hidden above/left of
+    /// the viewport. Returns 0 if the first visible item is fully visible.
+    ///
+    /// # Example
+    ///
+    /// If message #5 is the first visible item but its first 2 rows are scrolled off the top,
+    /// this returns 2. Combined with `scroll_offset_index()`, you can calculate the exact
+    /// scroll position in pixels/rows.
+    #[must_use]
+    pub fn scroll_truncation(&self) -> u16 {
+        self.view_state.first_truncated
+    }
 }


### PR DESCRIPTION
## Overview
This patch adds a `scroll_truncation()` public method to `ListState` that exposes the `first_truncated` field. 

This was needed in a project of mine for accurate mouse click-to-item mapping when list items have variable heights.

When implementing mouse click handling for a `ListView` with variable-height items, we encountered a frustrating bug:

**Symptom:** Mouse clicks on messages were accurate when the list was unscrolled, but became progressively offset (by 1-5 rows) as the user scrolled down. The offset was most noticeable when scrolled to the bottom of the list.

**Root Cause:** Calculating scroll offset using only `scroll_offset_index()`:
```rust
// My calculation (INCORRECT)
let first_visible_idx = list_state.scroll_offset_index();
let scroll_offset = sum_heights_before(first_visible_idx);
```

This works fine when the first visible item is fully visible, but fails when it's partially scrolled off the top. ListView internally tracks BOTH the index (`offset`) AND the truncation (`first_truncated`), but only exposes the index. I tried manually replicating ListView's scrolling logic to predict the truncation amount, but it wasn't clever to try and copy the ListView's internal state.

## Changes
- Added `scroll_truncation()` public method to `ListState`
- Returns `u16` representing rows/columns hidden above/left of viewport
- Documented with example use case
- Follows existing naming convention (`scroll_offset_index()`)
- Pairs naturally with `scroll_offset_index()` as the complete scroll state

## Use Case Example
```rust
// Calculate exact scroll position for mouse click handling
let first_visible_idx = list_state.scroll_offset_index();
let first_truncated = list_state.scroll_truncation();

// Now we have the COMPLETE scroll state
let total_scroll_offset = calculate_offset_before(first_visible_idx)
                          + first_truncated;

// Accurately map click coordinate to item
let clicked_item = find_item_at_coordinate(click_y, total_scroll_offset);
```

