### PR TITLE
Use crossterm dependency only for examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,6 @@ keywords = ["tui", "ratatui", "widget", "list", "widgetlist"]
 readme = "README.md"
 license = "MIT"
 
-[features]
-default = []
-crossterm = ["ratatui/crossterm"]
-
 [dependencies]
 ratatui = { version = "0.29", default-features = false }
 


### PR DESCRIPTION
Hi!

I'm integrating this widget into an embedded ESP32 project using Mousefood. Ratatui brings crossterm by default. However, Crossterm isn’t compatible with the embedded environment and fails to compile.

This pull request updates the configuration in `Cargo.toml` to fix this problem.

* Added a `[features]` section with a `default` feature and a `crossterm` feature, allowing more granular control over enabled features.

Dependency updates:

* Changed the `ratatui` dependency to disable default features, enabling explicit feature selection.
* Updated `ratatui` in `[dev-dependencies]` to explicitly enable the `crossterm` feature.
* Upgraded the `crossterm` dependency to version `0.29` in `[dev-dependencies]`.