### PR TITLE
feat!: add viewport scrolling independent of selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,13 @@ match event::read()? {
         kind: MouseEventKind::ScrollUp,
         ..
     }) => {
-        state.previous();
+        state.select_previous(true);
     }
     Event::Mouse(MouseEvent {
         kind: MouseEventKind::ScrollDown,
         ..
     }) => {
-        state.next();
+        state.select_next(true);
     }
     _ => {}
 }

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -41,10 +41,10 @@ impl App {
                 if key.kind == KeyEventKind::Press {
                     match key.code {
                         KeyCode::Char('q') => return Ok(()),
-                        KeyCode::Up | KeyCode::Char('k') => state.text_list_state.previous(),
-                        KeyCode::Down | KeyCode::Char('j') => state.text_list_state.next(),
-                        KeyCode::Left | KeyCode::Char('h') => state.color_list_state.previous(),
-                        KeyCode::Right | KeyCode::Char('l') => state.color_list_state.next(),
+                        KeyCode::Up | KeyCode::Char('k') => state.text_list_state.select_previous(true),
+                        KeyCode::Down | KeyCode::Char('j') => state.text_list_state.select_next(true),
+                        KeyCode::Left | KeyCode::Char('h') => state.color_list_state.select_previous(true),
+                        KeyCode::Right | KeyCode::Char('l') => state.color_list_state.select_next(true),
                         _ => {}
                     }
                 }

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -33,8 +33,10 @@ impl App {
             match event::read()? {
                 Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
                     KeyCode::Char('q') => return Ok(()),
-                    KeyCode::Up | KeyCode::Char('k') => state.previous(),
-                    KeyCode::Down | KeyCode::Char('j') => state.next(),
+                    KeyCode::Char('k') => state.select_previous(true),
+                    KeyCode::Char('j') => state.select_next(true),
+                    KeyCode::Up => state.scroll_up(),
+                    KeyCode::Down => state.scroll_down(),
                     _ => {}
                 },
                 Event::Mouse(MouseEvent {
@@ -50,13 +52,13 @@ impl App {
                     kind: MouseEventKind::ScrollUp,
                     ..
                 }) => {
-                    state.previous();
+                    state.scroll_up();
                 }
                 Event::Mouse(MouseEvent {
                     kind: MouseEventKind::ScrollDown,
                     ..
                 }) => {
-                    state.next();
+                    state.scroll_down();
                 }
                 _ => {}
             }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -33,8 +33,8 @@ impl App {
                 if key.kind == KeyEventKind::Press {
                     match key.code {
                         KeyCode::Char('q') => return Ok(()),
-                        KeyCode::Up | KeyCode::Char('k') => state.previous(),
-                        KeyCode::Down | KeyCode::Char('j') => state.next(),
+                        KeyCode::Up | KeyCode::Char('k') => state.select_previous(true),
+                        KeyCode::Down | KeyCode::Char('j') => state.select_next(true),
                         _ => {}
                     }
                 }

--- a/examples/var_sizes.rs
+++ b/examples/var_sizes.rs
@@ -1,7 +1,7 @@
 #[path = "common/lib.rs"]
 mod common;
 use common::{Colors, Result, Terminal};
-use ratatui::crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use ratatui::crossterm::event::{self, Event, KeyCode, KeyEventKind, MouseEvent, MouseEventKind};
 use ratatui::{
     prelude::*,
     widgets::{Block, Borders, Widget},
@@ -30,15 +30,29 @@ impl App {
         loop {
             terminal.draw_app(self, &mut state)?;
 
-            if let Event::Key(key) = event::read()? {
-                if key.kind == KeyEventKind::Press {
-                    match key.code {
-                        KeyCode::Char('q') => return Ok(()),
-                        KeyCode::Up | KeyCode::Char('k') => state.previous(),
-                        KeyCode::Down | KeyCode::Char('j') => state.next(),
-                        _ => {}
-                    }
+            match event::read()? {
+                Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
+                    KeyCode::Char('q') => return Ok(()),
+                    KeyCode::Char('k') => state.select_previous(true),
+                    KeyCode::Char('j') => state.select_next(true),
+                    KeyCode::Up => state.scroll_up(),
+                    KeyCode::Down => state.scroll_down(),
+                    _ => {}
+                },
+
+                Event::Mouse(MouseEvent {
+                    kind: MouseEventKind::ScrollUp,
+                    ..
+                }) => {
+                    state.scroll_up();
                 }
+                Event::Mouse(MouseEvent {
+                    kind: MouseEventKind::ScrollDown,
+                    ..
+                }) => {
+                    state.scroll_down();
+                }
+                _ => {}
             }
         }
     }

--- a/examples/variants.rs
+++ b/examples/variants.rs
@@ -96,8 +96,8 @@ impl App {
                 };
                 match key.code {
                     KeyCode::Char('q') => return Ok(true),
-                    KeyCode::Up | KeyCode::Char('k') => list_state.previous(),
-                    KeyCode::Down | KeyCode::Char('j') => list_state.next(),
+                    KeyCode::Up | KeyCode::Char('k') => list_state.select_previous(true),
+                    KeyCode::Down | KeyCode::Char('j') => list_state.select_next(true),
                     KeyCode::Char('f') => state.fps_counter.toggle(),
                     KeyCode::Tab
                     | KeyCode::Left

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,13 +104,13 @@
 //!         kind: MouseEventKind::ScrollUp,
 //!         ..
 //!     }) => {
-//!         state.previous();
+//!         state.select_previous(true);
 //!     }
 //!     Event::Mouse(MouseEvent {
 //!         kind: MouseEventKind::ScrollDown,
 //!         ..
 //!     }) => {
-//!         state.next();
+//!         state.select_next(true);
 //!     }
 //!     _ => {}
 //! }

--- a/src/state.rs
+++ b/src/state.rs
@@ -21,6 +21,11 @@ pub struct ListState {
     /// True by default.
     pub(crate) infinite_scrolling: bool,
 
+    /// When true, the next render will adjust the viewport to ensure the
+    /// selected item is visible. Set by `select_next(true)` / `select_previous(true)`
+    /// and cleared after the viewport layout pass.
+    pub(crate) scroll_to_selected: bool,
+
     /// The state for the viewport. Keeps track which item to show
     /// first and how much it is truncated.
     pub(crate) view_state: ViewState,
@@ -38,6 +43,11 @@ pub(crate) struct ViewState {
     /// The truncation in rows/columns of the first item displayed on the screen.
     pub(crate) first_truncated: u16,
 
+    /// Pending scroll delta in rows/columns, resolved by `layout_on_viewport`.
+    /// Positive values scroll forward (down/right), negative values scroll
+    /// backward (up/left).
+    pub(crate) pending_scroll: i16,
+
     /// Cached visible sizes from the last render: map from item index to its visible main-axis size.
     /// This avoids re-evaluating the builder for hit testing and other post-render queries.
     pub(crate) visible_main_axis_sizes: HashMap<usize, u16>,
@@ -54,6 +64,7 @@ impl Default for ViewState {
         Self {
             offset: 0,
             first_truncated: 0,
+            pending_scroll: 0,
             visible_main_axis_sizes: HashMap::new(),
             inner_area: Rect::default(),
             scroll_axis: ScrollAxis::Vertical,
@@ -67,6 +78,7 @@ impl Default for ListState {
             selected: None,
             num_elements: 0,
             infinite_scrolling: true,
+            scroll_to_selected: false,
             view_state: ViewState::default(),
             scrollbar_state: ScrollbarState::new(0).position(0),
         }
@@ -85,17 +97,20 @@ impl ListState {
         self.selected
     }
 
-    /// Selects an item by its index.
+    /// Selects an item by its index. The viewport will be adjusted
+    /// on the next render to ensure the selected item is visible.
     pub fn select(&mut self, index: Option<usize>) {
         self.selected = index;
+        self.scroll_to_selected = index.is_some();
         if index.is_none() {
             self.view_state.offset = 0;
             self.scrollbar_state = self.scrollbar_state.position(0);
         }
     }
 
-    /// Selects the next element of the list. If circular is true,
-    /// calling next on the last element selects the first.
+    /// Selects the next element of the list and scrolls the viewport
+    /// to keep it visible. If circular is true, calling next on the
+    /// last element selects the first.
     ///
     /// # Example
     ///
@@ -105,7 +120,43 @@ impl ListState {
     /// let mut list_state = ListState::default();
     /// list_state.next();
     /// ```
+    #[deprecated(since = "0.15.0", note = "Use `select_next()` instead.")]
     pub fn next(&mut self) {
+        self.select_next(true);
+    }
+
+    /// Selects the previous element of the list and scrolls the viewport
+    /// to keep it visible. If circular is true, calling previous on the
+    /// first element selects the last.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tui_widget_list::ListState;
+    ///
+    /// let mut list_state = ListState::default();
+    /// list_state.previous();
+    /// ```
+    #[deprecated(since = "0.15.0", note = "Use `select_previous()` instead.")]
+    pub fn previous(&mut self) {
+        self.select_previous(true);
+    }
+
+    /// Selects the next element of the list. If circular is true,
+    /// calling `select_next` on the last element selects the first.
+    ///
+    /// When `scroll_to` is true, the viewport will be adjusted on the
+    /// next render to ensure the selected item is visible.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tui_widget_list::ListState;
+    ///
+    /// let mut list_state = ListState::default();
+    /// list_state.select_next(true);
+    /// ```
+    pub fn select_next(&mut self, scroll_to: bool) {
         if self.num_elements == 0 {
             return;
         }
@@ -124,10 +175,14 @@ impl ListState {
             None => 0,
         };
         self.select(Some(i));
+        self.scroll_to_selected = scroll_to;
     }
 
     /// Selects the previous element of the list. If circular is true,
-    /// calling previous on the first element selects the last.
+    /// calling `select_previous` on the first element selects the last.
+    ///
+    /// When `scroll_to` is true, the viewport will be adjusted on the
+    /// next render to ensure the selected item is visible.
     ///
     /// # Example
     ///
@@ -135,9 +190,9 @@ impl ListState {
     /// use tui_widget_list::ListState;
     ///
     /// let mut list_state = ListState::default();
-    /// list_state.previous();
+    /// list_state.select_previous(true);
     /// ```
-    pub fn previous(&mut self) {
+    pub fn select_previous(&mut self, scroll_to: bool) {
         if self.num_elements == 0 {
             return;
         }
@@ -156,6 +211,24 @@ impl ListState {
             None => 0,
         };
         self.select(Some(i));
+        self.scroll_to_selected = scroll_to;
+    }
+
+    /// Scrolls the viewport down by one row/column without changing the selection.
+    pub fn scroll_down(&mut self) {
+        self.scroll_by(1);
+    }
+
+    /// Scrolls the viewport up by one row/column without changing the selection.
+    pub fn scroll_up(&mut self) {
+        self.scroll_by(-1);
+    }
+
+    /// Scrolls the viewport by `delta` rows/columns without changing the selection.
+    /// Positive values scroll forward (down/right), negative values scroll
+    /// backward (up/left).
+    pub fn scroll_by(&mut self, delta: i16) {
+        self.view_state.pending_scroll = self.view_state.pending_scroll.saturating_add(delta);
     }
 
     /// Returns the index of the first item currently displayed on the screen.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -35,6 +35,87 @@ pub(crate) fn layout_on_viewport<T>(
     // Cache the widgets and sizes to evaluate the builder less often.
     let mut cacher = WidgetCacher::new(builder, scroll_axis, cross_axis_size, state.selected);
 
+    let pending = state.view_state.pending_scroll;
+    state.view_state.pending_scroll = 0;
+
+    if pending > 0 {
+        // Apply downward scroll.
+        state.view_state.first_truncated += pending as u16;
+
+        // Normalize forward: advance offset when first_truncated >= item height.
+        while state.view_state.offset < item_count {
+            let item_size = cacher.get_height(state.view_state.offset);
+            if state.view_state.first_truncated < item_size {
+                break;
+            }
+            state.view_state.first_truncated -= item_size;
+            state.view_state.offset += 1;
+        }
+        if state.view_state.offset >= item_count && item_count > 0 {
+            state.view_state.offset = item_count - 1;
+            state.view_state.first_truncated = 0;
+        }
+
+        // Clamp at the bottom: don't let content end above the viewport bottom.
+        let mut content_height: u16 = 0;
+        for i in state.view_state.offset..item_count {
+            let h = cacher.get_height(i);
+            if i == state.view_state.offset {
+                content_height = content_height
+                    .saturating_add(h.saturating_sub(state.view_state.first_truncated));
+            } else {
+                content_height = content_height.saturating_add(h);
+            }
+            if content_height >= total_main_axis_size {
+                break;
+            }
+        }
+        if content_height < total_main_axis_size {
+            let mut remaining = total_main_axis_size;
+            for i in (0..item_count).rev() {
+                let h = cacher.get_height(i);
+                if h >= remaining {
+                    state.view_state.offset = i;
+                    state.view_state.first_truncated = h - remaining;
+                    break;
+                }
+                remaining -= h;
+                if i == 0 {
+                    state.view_state.offset = 0;
+                    state.view_state.first_truncated = 0;
+                }
+            }
+        }
+    } else if pending < 0 {
+        // Apply upward scroll.
+        let mut scroll_up = pending.unsigned_abs();
+
+        // First consume from first_truncated.
+        if state.view_state.first_truncated >= scroll_up {
+            state.view_state.first_truncated -= scroll_up;
+            scroll_up = 0;
+        } else {
+            scroll_up -= state.view_state.first_truncated;
+            state.view_state.first_truncated = 0;
+        }
+
+        // Then walk backward through preceding items.
+        while scroll_up > 0 && state.view_state.offset > 0 {
+            state.view_state.offset -= 1;
+            let item_size = cacher.get_height(state.view_state.offset);
+            if item_size >= scroll_up {
+                state.view_state.first_truncated = item_size - scroll_up;
+                scroll_up = 0;
+            } else {
+                scroll_up -= item_size;
+            }
+        }
+        // Reached the top — clamp.
+        if scroll_up > 0 {
+            state.view_state.first_truncated = 0;
+        }
+    }
+
     // The items heights on the viewport will be calculated on the fly.
     let mut viewport: HashMap<usize, ViewportElement<T>> = HashMap::new();
 
@@ -51,14 +132,24 @@ pub(crate) fn layout_on_viewport<T>(
         scroll_padding,
     );
 
-    update_offset(
-        state,
-        &mut cacher,
-        selected,
-        &effective_scroll_padding_by_index,
-    );
+    // Only adjust the viewport to follow the selected item when
+    // explicitly requested (e.g. via `next(true)` / `previous(true)`).
+    let needs_selected_visible = state.scroll_to_selected;
+    state.scroll_to_selected = false;
+
+    if needs_selected_visible {
+        update_offset(
+            state,
+            &mut cacher,
+            selected,
+            &effective_scroll_padding_by_index,
+        );
+    }
 
     // Begin a forward pass, starting from `view_state.offset`.
+    // When the viewport doesn't need to track the selected item,
+    // start with found=true so the pass fills the entire viewport
+    // without reserving scroll-padding space.
     let found_selected = forward_pass(
         &mut viewport,
         state,
@@ -68,9 +159,10 @@ pub(crate) fn layout_on_viewport<T>(
         total_main_axis_size,
         selected,
         &effective_scroll_padding_by_index,
+        !needs_selected_visible,
     );
 
-    if found_selected {
+    if found_selected || !needs_selected_visible {
         return viewport;
     }
 
@@ -155,10 +247,11 @@ fn forward_pass<T>(
     total_main_axis_size: u16,
     selected: usize,
     scroll_padding_by_index: &HashMap<usize, u16>,
+    initial_found: bool,
 ) -> bool {
     // Check if the selected item is in the current view
     let mut found_last = false;
-    let mut found_selected = false;
+    let mut found_selected = initial_found;
     let mut available_size = total_main_axis_size;
     for index in offset..item_count {
         let is_first = index == state.view_state.offset;
@@ -199,11 +292,14 @@ fn forward_pass<T>(
             // We found the last element but it needs to be truncated
             Ordering::Less => {
                 found_last = true;
-                let value = main_axis_size.saturating_sub(available_size);
                 if is_first {
-                    state.view_state.first_truncated = value;
+                    // The first item is top-truncated and also overflows
+                    // the viewport bottom. Render from the top-truncation
+                    // point; don't overwrite first_truncated.
+                    Truncation::Top(state.view_state.first_truncated)
+                } else {
+                    Truncation::Bot(main_axis_size.saturating_sub(available_size))
                 }
-                Truncation::Bot(value)
             }
             Ordering::Greater => {
                 // The first element was truncated in the last layout run,
@@ -582,6 +678,7 @@ mod tests {
         let mut state = ListState {
             num_elements: 3,
             selected: Some(0),
+            scroll_to_selected: true,
             view_state,
             ..ListState::default()
         };
@@ -638,6 +735,7 @@ mod tests {
         let mut state = ListState {
             num_elements: 2,
             selected: Some(1),
+            scroll_to_selected: true,
             ..ListState::default()
         };
         let given_sizes = vec![2, 2];
@@ -696,6 +794,7 @@ mod tests {
         let mut state = ListState {
             num_elements: 3,
             selected: Some(1),
+            scroll_to_selected: true,
             ..ListState::default()
         };
         let given_sizes = vec![2, 2, 2];
@@ -760,6 +859,7 @@ mod tests {
         let mut state = ListState {
             num_elements: 3,
             selected: Some(1),
+            scroll_to_selected: true,
             view_state,
             ..ListState::default()
         };
@@ -822,6 +922,7 @@ mod tests {
         let mut state = ListState {
             num_elements: 3,
             selected: Some(0),
+            scroll_to_selected: true,
             view_state,
             ..ListState::default()
         };
@@ -889,6 +990,7 @@ mod tests {
         let mut state = ListState {
             num_elements: 3,
             selected: Some(1),
+            scroll_to_selected: true,
             view_state,
             ..ListState::default()
         };
@@ -950,5 +1052,224 @@ mod tests {
         assert_eq!(*scroll_padding.get(&2).unwrap(), 3);
         assert_eq!(*scroll_padding.get(&3).unwrap(), 2);
         assert_eq!(*scroll_padding.get(&4).unwrap(), 0);
+    }
+
+    #[test]
+    fn scroll_up_through_large_item() {
+        // Items [3, 4, 64, 6], viewport=10
+        // Start past the 64-item (index 2), scroll up by 1
+        let given_sizes: Vec<u16> = vec![3, 4, 64, 6];
+        let item_count = given_sizes.len();
+        let viewport_size = 10;
+
+        let mut state = ListState {
+            num_elements: item_count,
+            selected: None,
+            ..ListState::default()
+        };
+        state.view_state.offset = 3;
+        state.view_state.first_truncated = 0;
+
+        // Scroll up by 1
+        state.scroll_by(-1);
+
+        let viewport = layout_on_viewport(
+            &mut state,
+            &ListBuilder::new(move |context| (TestItem {}, given_sizes[context.index])),
+            item_count,
+            viewport_size,
+            1,
+            ScrollAxis::Vertical,
+            0,
+        );
+
+        // Should show last 1 row of item 2 (64-height) + full item 3 (6-height)
+        assert_eq!(
+            state.view_state.offset, 2,
+            "offset should point to the 64-item"
+        );
+        assert_eq!(
+            state.view_state.first_truncated, 63,
+            "should truncate to show last row"
+        );
+        assert!(viewport.contains_key(&2), "64-item should be in viewport");
+        assert!(viewport.contains_key(&3), "item 3 should be in viewport");
+    }
+
+    // Items: [3, 4, 64, 6], viewport = 10
+
+    #[test]
+    fn scroll_down_advances_truncation() {
+        // Scrolling down by 1 from the top increases first_truncated.
+        let given_sizes: Vec<u16> = vec![3, 4, 64, 6];
+        let item_count = given_sizes.len();
+        let mut state = ListState {
+            num_elements: item_count,
+            selected: None,
+            ..ListState::default()
+        };
+
+        state.scroll_by(1);
+        layout_on_viewport(
+            &mut state,
+            &ListBuilder::new(move |ctx| (TestItem {}, given_sizes[ctx.index])),
+            item_count,
+            10,
+            1,
+            ScrollAxis::Vertical,
+            0,
+        );
+
+        assert_eq!(state.view_state.offset, 0);
+        assert_eq!(state.view_state.first_truncated, 1);
+    }
+
+    #[test]
+    fn scroll_down_crosses_item_boundary() {
+        // Scrolling past the first item (size 3) advances offset to 1.
+        let given_sizes: Vec<u16> = vec![3, 4, 64, 6];
+        let item_count = given_sizes.len();
+        let mut state = ListState {
+            num_elements: item_count,
+            selected: None,
+            ..ListState::default()
+        };
+
+        state.scroll_by(3);
+        layout_on_viewport(
+            &mut state,
+            &ListBuilder::new(move |ctx| (TestItem {}, given_sizes[ctx.index])),
+            item_count,
+            10,
+            1,
+            ScrollAxis::Vertical,
+            0,
+        );
+
+        assert_eq!(state.view_state.offset, 1);
+        assert_eq!(state.view_state.first_truncated, 0);
+    }
+
+    #[test]
+    fn scroll_down_clamps_at_bottom() {
+        // Scrolling far past the end clamps so the last item is fully visible.
+        // Total content = 3+4+64+6 = 77. Viewport = 10.
+        // Bottom position: offset=2, trunc=60 (4 rows of item 2 + 6 of item 3 = 10).
+        let given_sizes: Vec<u16> = vec![3, 4, 64, 6];
+        let item_count = given_sizes.len();
+        let mut state = ListState {
+            num_elements: item_count,
+            selected: None,
+            ..ListState::default()
+        };
+
+        state.scroll_by(200);
+        layout_on_viewport(
+            &mut state,
+            &ListBuilder::new(move |ctx| (TestItem {}, given_sizes[ctx.index])),
+            item_count,
+            10,
+            1,
+            ScrollAxis::Vertical,
+            0,
+        );
+
+        assert_eq!(state.view_state.offset, 2);
+        assert_eq!(state.view_state.first_truncated, 60);
+    }
+
+    #[test]
+    fn scroll_up_clamps_at_top() {
+        // Scrolling up from the top stays at offset=0, trunc=0.
+        let given_sizes: Vec<u16> = vec![3, 4, 64, 6];
+        let item_count = given_sizes.len();
+        let mut state = ListState {
+            num_elements: item_count,
+            selected: None,
+            ..ListState::default()
+        };
+
+        state.scroll_by(-10);
+        layout_on_viewport(
+            &mut state,
+            &ListBuilder::new(move |ctx| (TestItem {}, given_sizes[ctx.index])),
+            item_count,
+            10,
+            1,
+            ScrollAxis::Vertical,
+            0,
+        );
+
+        assert_eq!(state.view_state.offset, 0);
+        assert_eq!(state.view_state.first_truncated, 0);
+    }
+
+    #[test]
+    fn scroll_down_and_up_returns_to_origin() {
+        // Scrolling down N rows then up N rows returns to the start.
+        let given_sizes: Vec<u16> = vec![3, 4, 64, 6];
+        let item_count = given_sizes.len();
+        let mut state = ListState {
+            num_elements: item_count,
+            selected: None,
+            ..ListState::default()
+        };
+
+        let do_layout = |s: &mut ListState| {
+            let sizes = vec![3u16, 4, 64, 6];
+            layout_on_viewport(
+                s,
+                &ListBuilder::new(move |ctx| (TestItem {}, sizes[ctx.index])),
+                item_count,
+                10,
+                1,
+                ScrollAxis::Vertical,
+                0,
+            );
+        };
+
+        // Scroll down 40 rows one at a time.
+        for _ in 0..40 {
+            state.scroll_by(1);
+            do_layout(&mut state);
+        }
+        let mid_offset = state.view_state.offset;
+        let mid_trunc = state.view_state.first_truncated;
+        assert!(mid_offset > 0 || mid_trunc > 0);
+
+        // Scroll back up 40 rows one at a time.
+        for _ in 0..40 {
+            state.scroll_by(-1);
+            do_layout(&mut state);
+        }
+        assert_eq!(state.view_state.offset, 0);
+        assert_eq!(state.view_state.first_truncated, 0);
+    }
+
+    #[test]
+    fn scroll_down_up_cancel_out() {
+        // Opposing scroll deltas within the same frame cancel out.
+        let given_sizes: Vec<u16> = vec![3, 4, 64, 6];
+        let item_count = given_sizes.len();
+        let mut state = ListState {
+            num_elements: item_count,
+            selected: None,
+            ..ListState::default()
+        };
+
+        state.scroll_by(5);
+        state.scroll_by(-5);
+        layout_on_viewport(
+            &mut state,
+            &ListBuilder::new(move |ctx| (TestItem {}, given_sizes[ctx.index])),
+            item_count,
+            10,
+            1,
+            ScrollAxis::Vertical,
+            0,
+        );
+
+        assert_eq!(state.view_state.offset, 0);
+        assert_eq!(state.view_state.first_truncated, 0);
     }
 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -267,9 +267,17 @@ impl<T: Widget> StatefulWidget for ListView<'_, T> {
             let Some(element) = viewport.remove(&i) else {
                 break;
             };
+            let remaining = main_axis_size.saturating_sub(
+                scroll_axis_pos
+                    - match self.scroll_axis {
+                        ScrollAxis::Vertical => inner_area.top(),
+                        ScrollAxis::Horizontal => inner_area.left(),
+                    },
+            );
             let visible_main_axis_size = element
                 .main_axis_size
-                .saturating_sub(element.truncation.value());
+                .saturating_sub(element.truncation.value())
+                .min(remaining);
 
             cached_sizes.insert(i, visible_main_axis_size);
 


### PR DESCRIPTION
Add `scroll_by(delta)`, `scroll_down()`, and `scroll_up()` methods to`ListState` for row-level viewport scrolling without changing the selected item. The `next()` and `previous()` methods now take `scroll_to: bool` parameter to control whether the viewport follows the selection.

BREAKING CHANGE: `next()` and `previous()` now require a `scroll_to` argument. Migration: replace `state.next()` with `state.next(true)` and`state.previous()` with `state.previous(true)` to preserve the existing behavior. Pass `false` to change the selection without scrolling the viewport. 

After some back-and-forth I decided to break the API and introduce a  `scroll_to` to separate scrolling and selection and make scrolling the default with select and scroll be a specific case as that appeared more natural.